### PR TITLE
fix: result ordering in the partition index does not match with workers' ip ordering

### DIFF
--- a/master/src/main/scala/redsort/master/DistributedSorting.scala
+++ b/master/src/main/scala/redsort/master/DistributedSorting.scala
@@ -12,6 +12,7 @@ import redsort.jobs.scheduler.JobExecutionResult
 import org.log4s._
 import redsort.jobs.SourceLogger
 import redsort.jobs.messages.LongArg
+import scala.collection.immutable.TreeMap
 
 /** Configuration for `DistributedSorting`.
   *
@@ -166,7 +167,11 @@ object DistributedSorting {
 
   /** merge partition files into 128MB (or smaller) sized chunks
     */
-  def mergeStep(files: Map[Mid, Map[String, FileEntry]], outFileSize: Long): Seq[JobSpec] = {
+  def mergeStep(
+      unorderedFiles: Map[Mid, Map[String, FileEntry]],
+      outFileSize: Long
+  ): Seq[JobSpec] = {
+    val files = TreeMap.from(unorderedFiles)
     val inputPattern = "^@\\{working\\}\\/partition\\.(\\d+).(\\d+)$".r
     val (_, specs) = files.foldLeft((0, Seq[JobSpec]())) {
       case ((outputCounter, specs), (mid, machineFiles)) =>

--- a/src/test/scala/redsort/SortingSmallDataSpec.scala
+++ b/src/test/scala/redsort/SortingSmallDataSpec.scala
@@ -136,20 +136,17 @@ class SortingSmallDataSpec extends AsyncFunSuite with AsyncIOSpec {
     )(spawnMasterAndWorker)
   }
 
-  // Due to memory constraints in the CI env, this spends too much times (due to GC). I disable it for now temporarily, but it should be re-enabled later.
-  // TODO: re-enable this test
-  
-  // test("sorting-2x4-400MB") {
-  //   testSorting(
-  //     name = "sorting-2x4-400MB",
-  //     numMachines = 2,
-  //     numInputDirs = 2,
-  //     numFilesPerInputDir = 10,
-  //     recordsPerFile = 100 * 1000, // 100KB * 100 = 10MB
-  //     numWorkerThreads = 4,
-  //     masterPort = masterPortBase.getNext,
-  //     workerBasePort = workerPortBase.getNext
-  //   )(spawnMasterAndWorker)
-  // }
+  test("sorting-2x4-400MB") {
+    testSorting(
+      name = "sorting-2x4-400MB",
+      numMachines = 2,
+      numInputDirs = 2,
+      numFilesPerInputDir = 10,
+      recordsPerFile = 100 * 1000, // 100KB * 100 = 10MB
+      numWorkerThreads = 4,
+      masterPort = masterPortBase.getNext,
+      workerBasePort = workerPortBase.getNext
+    )(spawnMasterAndWorker)
+  }
 
 }


### PR DESCRIPTION
Fixes #47 

* Junseong said that the result of partition step might not be sorted. To make the ordering deterministic we expect, we have to sort the `files` before starting merge.
* The easiest way to sort `Map` is probably use `TreeMap`, which is `ordered Map`. `Mid` is just `Int`, so we don't need to add another `Ordering` or comparer.